### PR TITLE
Some more consistency changes to subgrad_distance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldDiff"
 uuid = "af67fdf4-a580-4b9f-bbec-742ef357defd"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@ Providing a derivative, differential or gradient for a given function, this pack
 For example
 
 * `grad_f` for a gradient ``\operatorname{grad} f``
-* `subgrad_f` for a subgradient ``\partial f``
+* `subgrad_f` for a subgradient from the subdifferential``\partial f``
 * `differential_f` for ``Df`` (also called pushforward)
 * `differential_f_variable` if `f` has multiple variables / parameters, since a usual writing in math is ``f_x`` in this case
 * `adjoint_differential_f` for pullbacks

--- a/src/ManifoldDiff.jl
+++ b/src/ManifoldDiff.jl
@@ -241,6 +241,6 @@ include("forward_diff.jl")
 include("reverse_diff.jl")
 include("zygote.jl")
 
-export riemannian_gradient, riemannian_gradient!, riemannian_Hessian, riemannian_Hessian!
+export riemannian_gradient, riemannian_gradient!, riemannian_Hessian, riemannian_Hessian!, subgrad_distance, subgrad_distance!
 export set_default_differential_backend!, default_differential_backend
 end # module

--- a/src/ManifoldDiff.jl
+++ b/src/ManifoldDiff.jl
@@ -241,6 +241,11 @@ include("forward_diff.jl")
 include("reverse_diff.jl")
 include("zygote.jl")
 
-export riemannian_gradient, riemannian_gradient!, riemannian_Hessian, riemannian_Hessian!, subgrad_distance, subgrad_distance!
+export riemannian_gradient,
+    riemannian_gradient!,
+    riemannian_Hessian,
+    riemannian_Hessian!,
+    subgrad_distance,
+    subgrad_distance!
 export set_default_differential_backend!, default_differential_backend
 end # module

--- a/src/subgradients.jl
+++ b/src/subgradients.jl
@@ -1,7 +1,7 @@
 
 @doc raw"""
-    subgrad_distance(M, q, p[, c = 1; atol = 0])
-    subgrad_distance!(M, X, q, p[, c = 1; atol = 0])
+    subgrad_distance(M, q, p[, c = 2; atol = 0])
+    subgrad_distance!(M, X, q, p[, c = 2; atol = 0])
 
 compute the subgradient of the distance (in place of `X`)
 
@@ -21,10 +21,10 @@ for ``c\neq 1`` or ``p\neq  q``. Note that for the remaining case ``c=1``,
 
 # Optional
 
-* `c` – (`1`) the exponent of the distance,  i.e. the default is the distance
+* `c` – (`2`) the exponent of the distance,  i.e. the default is the distance
 * `atol` – (`0`) the tolerance to use when evaluating the distance between `p` and `q`.
 """
-function subgrad_distance(M, q, p, c::Int = 2; atol = 0)
+function subgrad_distance(M, q, p, c::Int = 2; atol = zero(eltype(first(p))))
     if c == 2
         return -log(M, p, q)
     elseif c == 1 && distance(M, q, p) ≤ atol
@@ -33,10 +33,10 @@ function subgrad_distance(M, q, p, c::Int = 2; atol = 0)
         return -distance(M, p, q)^(c - 2) * log(M, p, q)
     end
 end
-function subgrad_distance!(M, X, q, p, c::Int = 2; atol = 0)
+function subgrad_distance!(M, X, q, p, c::Int = 2; atol = zero(eltype(first(p))))
     log!(M, X, p, q)
     if c == 2
-        X .*= -one(eltype(X))
+        X .*= -one(eltype(first(X)))
     elseif c == 1 && distance(M, q, p) ≤ atol
         normal_cone_vector!(M, X, p)
     else
@@ -46,7 +46,7 @@ function subgrad_distance!(M, X, q, p, c::Int = 2; atol = 0)
 end
 function normal_cone_vector(M, p)
     Y = rand(M; vector_at = p)
-    if norm(M, p, Y) > 1.0
+    if norm(M, p, Y) > one(eltype(first(Y)))
         Y ./= norm(M, p, Y)
         Y .*= rand()
     end
@@ -54,7 +54,7 @@ function normal_cone_vector(M, p)
 end
 function normal_cone_vector!(M, Y, p)
     ManifoldsBase.rand!(M, Y; vector_at = p)
-    if norm(M, p, Y) > 1.0
+    if norm(M, p, Y) > one(eltype(first(Y)))
         Y ./= norm(M, p, Y)
         Y .*= rand()
     end

--- a/src/subgradients.jl
+++ b/src/subgradients.jl
@@ -24,7 +24,7 @@ for ``c\neq 1`` or ``p\neq  q``. Note that for the remaining case ``c=1``,
 * `c` – (`2`) the exponent of the distance,  i.e. the default is the distance
 * `atol` – (`0`) the tolerance to use when evaluating the distance between `p` and `q`.
 """
-function subgrad_distance(M, q, p, c::Int = 2; atol = zero(eltype(first(p))))
+function subgrad_distance(M, q, p, c::Int = 2; atol = zero(number_eltype(p)))
     if c == 2
         return -log(M, p, q)
     elseif c == 1 && distance(M, q, p) ≤ atol
@@ -33,10 +33,10 @@ function subgrad_distance(M, q, p, c::Int = 2; atol = zero(eltype(first(p))))
         return -distance(M, p, q)^(c - 2) * log(M, p, q)
     end
 end
-function subgrad_distance!(M, X, q, p, c::Int = 2; atol = zero(eltype(first(p))))
+function subgrad_distance!(M, X, q, p, c::Int = 2; atol = zero(number_eltype(p)))
     log!(M, X, p, q)
     if c == 2
-        X .*= -one(eltype(first(X)))
+        X .*= -one(number_eltype(X))
     elseif c == 1 && distance(M, q, p) ≤ atol
         normal_cone_vector!(M, X, p)
     else
@@ -46,7 +46,7 @@ function subgrad_distance!(M, X, q, p, c::Int = 2; atol = zero(eltype(first(p)))
 end
 function normal_cone_vector(M, p)
     Y = rand(M; vector_at = p)
-    if norm(M, p, Y) > one(eltype(first(Y)))
+    if norm(M, p, Y) > one(number_eltype(Y))
         Y ./= norm(M, p, Y)
         Y .*= rand()
     end
@@ -54,7 +54,7 @@ function normal_cone_vector(M, p)
 end
 function normal_cone_vector!(M, Y, p)
     ManifoldsBase.rand!(M, Y; vector_at = p)
-    if norm(M, p, Y) > one(eltype(first(Y)))
+    if norm(M, p, Y) > one(number_eltype(Y))
         Y ./= norm(M, p, Y)
         Y .*= rand()
     end


### PR DESCRIPTION
I updated the docs to _actually_ reflect the correct default exponent (`c=2`), and replaced instances where `0` and `1.0` occurred with `zero` and `one` respectively.
Finally, I added `subgrad_distance` to the exported functions.