### PR TITLE
Adapt to Julia 1.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ["1.6", "1.10", "~1.11.0-0"]
+        julia-version: ["lts", "1", "pre"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: "1.10"
+          version: "1"
       - uses: julia-actions/julia-docdeploy@v1
         env:
           PYTHON: ""

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldDiff"
 uuid = "af67fdf4-a580-4b9f-bbec-742ef357defd"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.3.13"
+version = "0.3.14"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -34,7 +34,7 @@ ManifoldsBase = "0.15"
 RecursiveArrayTools = "2, 3"
 Requires = "1"
 StaticArrays = "1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"

--- a/ext/ManifoldDiffFiniteDiffExt.jl
+++ b/ext/ManifoldDiffFiniteDiffExt.jl
@@ -1,16 +1,8 @@
 module ManifoldDiffFiniteDiffExt
 
-if isdefined(Base, :get_extension)
-    using ManifoldDiff
-    using ManifoldDiff: FiniteDiffBackend
-    using FiniteDiff
-else
-    # imports need to be relative for Requires.jl-based workflows:
-    # https://github.com/JuliaArrays/ArrayInterface.jl/pull/387
-    using ..ManifoldDiff
-    using ..ManifoldDiff: FiniteDiffBackend
-    using ..FiniteDiff
-end
+using ManifoldDiff
+using ManifoldDiff: FiniteDiffBackend
+using FiniteDiff
 
 function ManifoldDiff._derivative(f, p, ::FiniteDiffBackend{Method}) where {Method}
     return FiniteDiff.finite_difference_derivative(f, p, Method)

--- a/ext/ManifoldDiffFiniteDifferencesExt.jl
+++ b/ext/ManifoldDiffFiniteDifferencesExt.jl
@@ -1,16 +1,8 @@
 module ManifoldDiffFiniteDifferencesExt
 
-if isdefined(Base, :get_extension)
-    using ManifoldDiff
-    using ManifoldDiff: FiniteDifferencesBackend
-    using FiniteDifferences
-else
-    # imports need to be relative for Requires.jl-based workflows:
-    # https://github.com/JuliaArrays/ArrayInterface.jl/pull/387
-    using ..ManifoldDiff
-    using ..ManifoldDiff: FiniteDifferencesBackend
-    using ..FiniteDifferences
-end
+using ManifoldDiff
+using ManifoldDiff: FiniteDifferencesBackend
+using FiniteDifferences
 
 function ManifoldDiff.FiniteDifferencesBackend()
     return FiniteDifferencesBackend(central_fdm(5, 1))

--- a/ext/ManifoldDiffForwardDiffExt.jl
+++ b/ext/ManifoldDiffForwardDiffExt.jl
@@ -1,16 +1,8 @@
 module ManifoldDiffForwardDiffExt
 
-if isdefined(Base, :get_extension)
-    using ManifoldDiff
-    using ManifoldDiff: ForwardDiffBackend
-    using ForwardDiff
-else
-    # imports need to be relative for Requires.jl-based workflows:
-    # https://github.com/JuliaArrays/ArrayInterface.jl/pull/387
-    using ..ManifoldDiff
-    using ..ManifoldDiff: ForwardDiffBackend
-    using ..ForwardDiff
-end
+using ManifoldDiff
+using ManifoldDiff: ForwardDiffBackend
+using ForwardDiff
 
 function ManifoldDiff._derivative(f, p, ::ForwardDiffBackend)
     return ForwardDiff.derivative(f, p)

--- a/ext/ManifoldDiffReverseDiffExt.jl
+++ b/ext/ManifoldDiffReverseDiffExt.jl
@@ -1,16 +1,8 @@
 module ManifoldDiffReverseDiffExt
 
-if isdefined(Base, :get_extension)
-    using ManifoldDiff
-    using ManifoldDiff: ReverseDiffBackend
-    using ReverseDiff
-else
-    # imports need to be relative for Requires.jl-based workflows:
-    # https://github.com/JuliaArrays/ArrayInterface.jl/pull/387
-    using ..ManifoldDiff
-    using ..ManifoldDiff: ReverseDiffBackend
-    using ..ReverseDiff
-end
+using ManifoldDiff
+using ManifoldDiff: ReverseDiffBackend
+using ReverseDiff
 
 function ManifoldDiff._gradient(f, p, ::ReverseDiffBackend)
     return ReverseDiff.gradient(f, p)

--- a/ext/ManifoldDiffZygoteExt.jl
+++ b/ext/ManifoldDiffZygoteExt.jl
@@ -1,16 +1,8 @@
 module ManifoldDiffZygoteExt
 
-if isdefined(Base, :get_extension)
-    using ManifoldDiff
-    using ManifoldDiff: ZygoteDiffBackend
-    using Zygote
-else
-    # imports need to be relative for Requires.jl-based workflows:
-    # https://github.com/JuliaArrays/ArrayInterface.jl/pull/387
-    using ..ManifoldDiff
-    using ..ManifoldDiff: ZygoteDiffBackend
-    using ..Zygote
-end
+using ManifoldDiff
+using ManifoldDiff: ZygoteDiffBackend
+using Zygote
 
 function ManifoldDiff._gradient(f, p, ::ZygoteDiffBackend)
     return Zygote.gradient(f, p)[1]

--- a/src/ManifoldDiff.jl
+++ b/src/ManifoldDiff.jl
@@ -181,28 +181,6 @@ include("embedded_diff.jl")
 
 
 function __init__()
-    @static if !isdefined(Base, :get_extension)
-        @require FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41" begin
-            include("../ext/ManifoldDiffFiniteDiffExt.jl")
-        end
-
-        @require FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000" begin
-            include("../ext/ManifoldDiffFiniteDifferencesExt.jl")
-        end
-
-        @require ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210" begin
-            include("../ext/ManifoldDiffForwardDiffExt.jl")
-        end
-
-        @require ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267" begin
-            include("../ext/ManifoldDiffReverseDiffExt.jl")
-        end
-
-        @require Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f" begin
-            include("../ext//ManifoldDiffZygoteExt.jl")
-        end
-    end
-
     # There is likely no way to set defaults without Requires.jl
     @require FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000" begin
         if default_differential_backend() === NoneDiffBackend()


### PR DESCRIPTION
Hi there, I was looking at ways to tackle #49 and I thought that if you want to use DI, we might as well upgrate to Julia 1.10 because I dropped 1.6 when the new LTS was announced.
Here are a few changes, feel free to take them or leave them: 

- Bump Julia compat to 1.10
- Update CI to run on 3 automatically updated versions: `lts`, `1` (stable release) and `pre` (upcoming pre-release)
- Remove Requires-related extension boilerplate (but leave default backend choice)